### PR TITLE
Adds some initial V3 API support.

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import reactor.core.publisher.Mono;
 
 public interface CFAccessor {
@@ -25,6 +26,22 @@ public interface CFAccessor {
 	Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);	
 
 	Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId);
+
+	Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName);
+
+	Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3();
+
+	Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName);
+
+	Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId);
+
+	Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId);
+
+	Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId);
+
+	Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId);
+
+	Mono<org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId);
 	
 	void reset();
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -14,6 +14,8 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -263,6 +265,53 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	@Override
 	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 		return Mono.fromFuture(this.domainsInOrgCache.get(orgId));
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		// TODO: Implement cache
+		return this.parent.retrieveOrgIdV3(orgName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		// TODO: Implement cache
+		return this.parent.retrieveAllOrgIdsV3();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdV3(orgId, spaceName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdsInOrgV3(orgId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllApplicationIdsInSpaceV3(orgId, spaceId);
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceV3(spaceId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllDomainsV3(orgId);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -11,6 +11,8 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.cache.AutoRefreshingCacheMap;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
@@ -450,6 +452,53 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	@Override
 	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 		return this.domainCache.get(orgId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		// TODO: Implement cache
+		return this.parent.retrieveOrgIdV3(orgName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		// TODO: Implement cache
+		return this.parent.retrieveAllOrgIdsV3();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdV3(orgId, spaceName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdsInOrgV3(orgId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllApplicationIdsInSpaceV3(orgId, spaceId);
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceV3(spaceId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllDomainsV3(orgId);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -25,6 +25,8 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -220,5 +222,45 @@ public class CFAccessorSimulator implements CFAccessor {
 		
 		ListOrganizationDomainsResponse response = ListOrganizationDomainsResponse.builder().addAllResources(domains).build();
 		return Mono.just(response);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedRequestGeneratorFunctionV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedRequestGeneratorFunctionV3.java
@@ -1,0 +1,9 @@
+package org.cloudfoundry.promregator.cfaccessor;
+
+import org.cloudfoundry.client.v3.PaginatedRequest;
+
+@FunctionalInterface
+public interface PaginatedRequestGeneratorFunctionV3<T extends PaginatedRequest> {
+	// for the idea, see also https://stackoverflow.com/a/27872395 
+	T apply(int resultsPerPage, int pageNumber);
+}

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedResponseGeneratorFunctionV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedResponseGeneratorFunctionV3.java
@@ -1,0 +1,11 @@
+package org.cloudfoundry.promregator.cfaccessor;
+
+import org.cloudfoundry.client.v3.PaginatedResponse;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface PaginatedResponseGeneratorFunctionV3<S, T extends PaginatedResponse<?>> {
+	// for the idea, see also https://stackoverflow.com/a/27872395 
+	T apply(List<S> data, int numberOfPages);
+}

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -23,6 +23,10 @@ import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesRequest;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.Pagination;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceRequest;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.config.ConfigurationException;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.cloudfoundry.reactor.ConnectionContext;
@@ -42,7 +46,8 @@ import reactor.core.publisher.Mono;
 public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	private static final Logger log = LoggerFactory.getLogger(ReactiveCFAccessorImpl.class);
-	
+	private boolean v3Enabled;
+
 	@Value("${cf.api_host}")
 	private String apiHost;
 
@@ -220,6 +225,14 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 			
 			log.info("Target CF platform is running on API version {}", apiVersion);
 		}
+
+		String getRoot = this.cloudFoundryClient.getRootV3().block();
+		// Ensures v3 API exists
+
+		if (getRoot == null) {
+			log.warn("unable to get v3 endpoint of CF platform");
+			this.v3Enabled = false;
+		}
 	}
 
 	@Override
@@ -258,6 +271,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	private void setupPaginatedRequestFetcher() {
 		this.paginatedRequestFetcher = new ReactiveCFPaginatedRequestFetcher(this.internalMetrics, this.requestRateLimit, 
 				Duration.ofMillis(this.backoffDelay));
+	}
+
+	public boolean isV3Enabled() {
+		return this.v3Enabled;
 	}
 	
 	private static final GetInfoRequest DUMMY_GET_INFO_REQUEST = GetInfoRequest.builder().build();
@@ -391,5 +408,115 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, orgId, 
 		request, r -> this.cloudFoundryClient.organizations().listDomains(request), this.requestTimeoutDomains);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		// Note: even though we use the List request here, the number of values returned is either zero or one
+		// ==> No need for a paged request.
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest orgsRequest = org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder().name(orgName).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.ORG, orgName, orgsRequest,
+																	or -> this.cloudFoundryClient.organizationsV3()
+																								 .list(or), this.requestTimeoutOrg);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest> requestGenerator = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder()
+									.perPage(resultsPerPage)
+									.page(pageNumber)
+									.build();
+
+		PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.OrganizationResource, org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> responseGenerator = (list, numberOfPages) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+									 .addAllResources(list)
+									 .pagination(Pagination.builder().totalPages(numberOfPages).totalResults(list.size()).build())
+									 .build();
+
+		return this.paginatedRequestFetcher.performGenericPagedRetrievalV3(RequestType.ALL_ORGS, "(empty)", requestGenerator,
+																		 r -> this.cloudFoundryClient.organizationsV3().list(r),  this.requestTimeoutOrg, responseGenerator);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		// Note: even though we use the List request here, the number of values returned is either zero or one
+		// ==> No need for a paged request.
+
+		String key = String.format("%s|%s", orgId, spaceName);
+
+		org.cloudfoundry.client.v3.spaces.ListSpacesRequest spacesRequest = org.cloudfoundry.client.v3.spaces.ListSpacesRequest.builder().organizationId(orgId).name(spaceName).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.SPACE, key, spacesRequest, sr ->
+																		this.cloudFoundryClient.spacesV3().list(sr),
+																	this.requestTimeoutSpace);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.spaces.ListSpacesRequest> requestGenerator = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.spaces.ListSpacesRequest.builder()
+							 .organizationId(orgId)
+							 .perPage(resultsPerPage)
+							 .page(pageNumber)
+							 .build();
+
+		PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.spaces.SpaceResource, org.cloudfoundry.client.v3.spaces.ListSpacesResponse> responseGenerator = (list, numberOfPages) ->
+			org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+							  .addAllResources(list)
+							  .pagination(Pagination.builder().totalPages(numberOfPages).totalResults(list.size()).build())
+							  .build();
+
+
+		return this.paginatedRequestFetcher.performGenericPagedRetrievalV3(RequestType.SPACE_IN_ORG, orgId, requestGenerator,
+																		 r -> this.cloudFoundryClient.spacesV3().list(r),  this.requestTimeoutSpace, responseGenerator);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		String key = String.format("%s|%s", orgId, spaceId);
+
+		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.applications.ListApplicationsRequest> requestGenerator = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.applications.ListApplicationsRequest.builder()
+								   .organizationId(orgId)
+								   .spaceId(spaceId)
+								   .perPage(resultsPerPage)
+								   .page(pageNumber)
+								   .build();
+
+		PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.applications.ApplicationResource, org.cloudfoundry.client.v3.applications.ListApplicationsResponse> responseGenerator = (list, numberOfPages) ->
+			org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder()
+									.addAllResources(list)
+									.pagination(Pagination.builder().totalPages(numberOfPages).totalResults(list.size()).build())
+									.build();
+
+		return this.paginatedRequestFetcher.performGenericPagedRetrievalV3(RequestType.ALL_APPS_IN_SPACE, key, requestGenerator,
+																		 r -> this.cloudFoundryClient.applicationsV3().list(r), this.requestTimeoutAppInSpace, responseGenerator);
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// This API has drastically changed in v3 and does not support the same resources. This call for a space summary will probably
+		// take another call to list applications for a space, list routes for the apps, and list domains in the org
+		// Previously they were all grouped into this API
+
+		GetSpaceRequest request = GetSpaceRequest.builder().spaceId(spaceId).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.SPACE_SUMMARY, spaceId,
+																	request, r -> this.cloudFoundryClient.spacesV3().get(r), this.requestTimeoutAppSummary);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsRequest request = org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsRequest.builder().organizationId(orgId).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, orgId,
+																	request, r -> this.cloudFoundryClient.organizationsV3().listDomains(request), this.requestTimeoutDomains);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcher.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcher.java
@@ -31,7 +31,7 @@ class ReactiveCFPaginatedRequestFetcher {
 	private static final int RESULTS_PER_PAGE = MAX_SUPPORTED_RESULTS_PER_PAGE;
 
 	private InternalMetrics internalMetrics;
-	
+
 	private final RateLimiter cfccRateLimiter;
 
 	private final Duration initialBackoffDelay;
@@ -40,62 +40,63 @@ class ReactiveCFPaginatedRequestFetcher {
 		super();
 		this.internalMetrics = internalMetrics;
 		this.initialBackoffDelay = backoffDelay;
-		
+
 		if (requestRateLimit <= 0.0f) {
 			this.cfccRateLimiter = RateLimiter.create(Double.POSITIVE_INFINITY);
-		} else {
+		}
+		else {
 			this.cfccRateLimiter = RateLimiter.create(requestRateLimit);
 		}
 	}
 
 	/**
-	 * Returns an empty Mono, which is only resolved after the configured rate limit
-	 * could be acquired.
-	 * @param requestType the RequestType for which the rate limiting shall be acquired (mainly for statistical purpose only)
+	 * Returns an empty Mono, which is only resolved after the configured rate limit could be acquired.
+	 *
+	 * @param requestType
+	 * 	the RequestType for which the rate limiting shall be acquired (mainly for statistical purpose only)
+	 *
 	 * @return an empty Mono
 	 */
 	private Mono<Object> rateLimitingMono(RequestType requestType) {
 		return Mono.fromCallable(() -> {
-			
+
 			if (this.internalMetrics != null) {
 				this.internalMetrics.increaseRateLimitQueueSize();
 			}
-			
+
 			double waitTime = cfccRateLimiter.acquire(1);
-			
+
 			if (waitTime > 0.001) {
 				log.debug(String.format("Rate Limiting has throttled request of %s for %.3f seconds", requestType.getLoggerSuffix(), waitTime));
 			}
-			
+
 			if (this.internalMetrics != null) {
 				this.internalMetrics.decreaseRateLimitQueueSize();
 				this.internalMetrics.observeRateLimiterDuration(requestType.getMetricName(), waitTime);
 			}
-			
+
 			return new Object();
 		}).subscribeOn(Schedulers.boundedElastic())
-		.flatMap(x -> Mono.empty());
+				   .flatMap(x -> Mono.empty());
 	}
 
-	
+
 	/**
-	 * performs standard (raw) retrieval from the CF Cloud Controller of a single
-	 * page
-	 * 
+	 * performs standard (raw) retrieval from the CF Cloud Controller of a single page
+	 *
 	 * @param requestType
-	 *            the type information of the request which is being made
+	 * 	the type information of the request which is being made
 	 * @param key
-	 *            the key for which the request is being made (e.g. orgId,
-	 *            orgId|spaceName, ...)
+	 * 	the key for which the request is being made (e.g. orgId, orgId|spaceName, ...)
 	 * @param requestData
-	 *            an object which is being used as input parameter for the request
+	 * 	an object which is being used as input parameter for the request
 	 * @param requestFunction
-	 *            a function which calls the CF API operation, which is being made,
-	 *            <code>requestData</code> is used as input parameter for this
-	 *            function.
+	 * 	a function which calls the CF API operation, which is being made,
+	 * 	<code>requestData</code> is used as input parameter for this
+	 * 	function.
 	 * @param timeoutInMS
-	 *            the timeout value in milliseconds for a single data request to the
-	 *            CF Cloud Controller
+	 * 	the timeout value in milliseconds for a single data request to the CF Cloud Controller
+	 *
 	 * @return a Mono on the response provided by the CF Cloud Controller
 	 */
 	@SuppressWarnings("lgtm[java/sync-on-boxed-types]")
@@ -106,145 +107,214 @@ class ReactiveCFPaginatedRequestFetcher {
 	 * Moreover, the performance impact of the lock being engaged improperly is considered small,
 	 * as the duration of this method is assumed to be within milliseconds.
 	 * The effort of implementing a key to lock-object mapping (as alternative) is expected to be rather high
-	 * and would imply the risk of memory leaks. 
+	 * and would imply the risk of memory leaks.
 	 */
 	public <P, R> Mono<P> performGenericRetrieval(RequestType requestType, String key, R requestData,
-			Function<R, Mono<P>> requestFunction, int timeoutInMS) {
+												  Function<R, Mono<P>> requestFunction, int timeoutInMS) {
 		final String retrievalTypeName = requestType.getMetricName();
 		final String logName = requestType.getLoggerSuffix();
-		
-		final String lock = (this.getClass().getCanonicalName()+"|"+retrievalTypeName+"|"+key).intern();
-		
+
+		final String lock = (this.getClass().getCanonicalName() + "|" + retrievalTypeName + "|" + key).intern();
+
 		synchronized (lock) {
 			Mono<P> result = null;
 
 			ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, retrievalTypeName);
-			
+
 			final Mono<P> enrichedRequestFunction = requestFunction.apply(requestData)
-				.timeout(Duration.ofMillis(timeoutInMS));
+																   .timeout(Duration.ofMillis(timeoutInMS));
 			/*
-			 * Note 1: Applying (i.e. calling) the function "requestFunction" here  
-			 * does not trigger the request to be sent to the CFCC. 
+			 * Note 1: Applying (i.e. calling) the function "requestFunction" here
+			 * does not trigger the request to be sent to the CFCC.
 			 * Instead, it just will create the corresponding Flux/Mono, which does
-			 * not have any subscriber yet. 
-			 * 
+			 * not have any subscriber yet.
+			 *
 			 * Note 2: There is a major difference between the coding modeled
-			 * 
+			 *
 			 * requestFunction.apply(requestData).timeout(...)
-			 * 
+			 *
 			 * and
-			 * 
+			 *
 			 * someMono.flatMap(value -> requestFunction).timeout(...)
-			 * 
+			 *
 			 * The major point here is that the first variant applies the timeout
 			 * only to the stream returned by requestFunction.apply(...), whilst
 			 * the second variant applies it to
 			 * 1. someMono,
 			 * 2. the flatMap function
 			 * 3. the return value of the requestFunction
-			 * 
-			 * The difference there is that in the second variant counting 
+			 *
+			 * The difference there is that in the second variant counting
 			 * for the timeout starts already when someMono is subscribed to.
 			 * In the second variant, someMono is not considered.
-			 * 
+			 *
 			 * In this case here, the difference may be huge: The first variant
-			 * puts a timeout on each request (which is what we want). The 
+			 * puts a timeout on each request (which is what we want). The
 			 * second variant means that timeout would be counting from the
-			 * first subscription happening - which is wrong especially in case 
+			 * first subscription happening - which is wrong especially in case
 			 * of retry attempts.
 			 */
 
 			result = this.rateLimitingMono(requestType).then(Mono.just(reactiveTimer))
-					// start the timer
-					.flatMap(timer -> {
-						timer.start();
-						return Mono.just(0 /* any value will just do; will be ignored */); // Cannot use Mono.empty() here!
-					}).flatMap(nothing -> enrichedRequestFunction)
-					.retryWhen(Retry.backoff(2, this.initialBackoffDelay))
-					/*
-					 * Note: Don't push the retry attempts above into enrichedRequestFunction!
-					 * It would change the semantics of the metric behind the timer.
-					 * see also https://github.com/promregator/promregator/pull/174/files#r392031592
-					 */
-					.doOnError(throwable -> {
-						Throwable unwrappedThrowable = Exceptions.unwrap(throwable);
-						if (unwrappedThrowable instanceof TimeoutException) {
-							log.error(String.format(
-									"Async retrieval of %s with key %s caused a timeout after %dms even though we tried three times",
-									logName, key, timeoutInMS));
-						} else if (unwrappedThrowable instanceof OutOfMemoryError){
-							// This may be an direct memory or a heap error!
-							// Using String.format and/or log.error here is a bad idea - it takes memory!
-							
-							if (System.getenv("VCAP_APPLICATION") != null) {
-								// we assume that we are running on a Cloud Foundry container
-								this.triggerOutOfMemoryRestart();
-							}
-							
-						} else {
-							log.error(String.format("Async retrieval of %s with key %s raised a reactor error", logName,
-									key), unwrappedThrowable);
-						}
-					})
-					// stop the timer
-					.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
-						tuple.getT2().stop();
-						return tuple.getT1();
-					}).log(log.getName() + "." + logName, Level.FINE).cache();
+						 // start the timer
+						 .flatMap(timer -> {
+							 timer.start();
+							 return Mono.just(0 /* any value will just do; will be ignored */); // Cannot use Mono.empty() here!
+						 }).flatMap(nothing -> enrichedRequestFunction)
+						 .retryWhen(Retry.backoff(2, this.initialBackoffDelay))
+						 /*
+						  * Note: Don't push the retry attempts above into enrichedRequestFunction!
+						  * It would change the semantics of the metric behind the timer.
+						  * see also https://github.com/promregator/promregator/pull/174/files#r392031592
+						  */
+						 .doOnError(throwable -> {
+							 Throwable unwrappedThrowable = Exceptions.unwrap(throwable);
+							 if (unwrappedThrowable instanceof TimeoutException) {
+								 log.error(String.format(
+									 "Async retrieval of %s with key %s caused a timeout after %dms even though we tried three times",
+									 logName, key, timeoutInMS));
+							 }
+							 else if (unwrappedThrowable instanceof OutOfMemoryError) {
+								 // This may be an direct memory or a heap error!
+								 // Using String.format and/or log.error here is a bad idea - it takes memory!
+
+								 if (System.getenv("VCAP_APPLICATION") != null) {
+									 // we assume that we are running on a Cloud Foundry container
+									 this.triggerOutOfMemoryRestart();
+								 }
+
+							 }
+							 else {
+								 log.error(String.format("Async retrieval of %s with key %s raised a reactor error", logName,
+														 key), unwrappedThrowable);
+							 }
+						 })
+						 // stop the timer
+						 .zipWith(Mono.just(reactiveTimer)).map(tuple -> {
+					tuple.getT2().stop();
+					return tuple.getT1();
+				}).log(log.getName() + "." + logName, Level.FINE).cache();
 
 			return result;
 		}
 	}
 
-	@SuppressFBWarnings(value = "DM_EXIT", justification="Restart of JVM is done intentionally here!")
+	@SuppressFBWarnings(value = "DM_EXIT", justification = "Restart of JVM is done intentionally here!")
 	private void triggerOutOfMemoryRestart() {
 		System.err.println("Out of Memory situation detected on talking to the Cloud Foundry Controller; restarting application");
 		System.exit(ExitCodes.CF_ACCESSOR_OUT_OF_MEMORY);
 	}
-	
+
 	/**
-	 * performs a retrieval from the CF Cloud Controller fetching all pages
-	 * available.
-	 * 
+	 * performs a retrieval from the CF Cloud Controller fetching all pages available.
+	 *
 	 * @param requestType
-	 *            the type information of the request which is being made
+	 * 	the type information of the request which is being made
 	 * @param key
-	 *            the key for which the request is being made (e.g. orgId,
-	 *            orgId|spaceName, ...)
+	 * 	the key for which the request is being made (e.g. orgId, orgId|spaceName, ...)
 	 * @param requestGenerator
-	 *            a request generator function, which permits creating request
-	 *            objects instance for a given set of page parameters (e.g. for
-	 *            which page, using which page size, ...)
+	 * 	a request generator function, which permits creating request objects instance for a given set of page parameters (e.g. for which page, using
+	 * 	which page size, ...)
 	 * @param requestFunction
-	 *            a function which calls the CF API operation, which is being made.
+	 * 	a function which calls the CF API operation, which is being made.
 	 * @param timeoutInMS
-	 *            the timeout value in milliseconds for a single data request to the
-	 *            CF Cloud Controller
+	 * 	the timeout value in milliseconds for a single data request to the CF Cloud Controller
 	 * @param responseGenerator
-	 *            a response generator function, which permits creating a response
-	 *            object, which contains the collected resources of all pages
-	 *            retrieved.
+	 * 	a response generator function, which permits creating a response object, which contains the collected resources of all pages retrieved.
+	 *
 	 * @return a Mono on the response provided by the CF Cloud Controller
 	 */
 	public <S, P extends PaginatedResponse<?>, R extends PaginatedRequest> Mono<P> performGenericPagedRetrieval(
-			RequestType requestType, String key, PaginatedRequestGeneratorFunction<R> requestGenerator,
-			Function<R, Mono<P>> requestFunction, int timeoutInMS,
-			PaginatedResponseGeneratorFunction<S, P> responseGenerator) {
+		RequestType requestType, String key, PaginatedRequestGeneratorFunction<R> requestGenerator,
+		Function<R, Mono<P>> requestFunction, int timeoutInMS,
+		PaginatedResponseGeneratorFunction<S, P> responseGenerator) {
 
 		final String pageRetrievalType = requestType.getMetricName() + "_singlePage";
 
 		ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, pageRetrievalType);
 
 		Mono<P> firstPage = Mono.just(reactiveTimer).doOnNext(ReactiveTimer::start).flatMap(dummy ->
-				this.performGenericRetrieval(requestType, key, requestGenerator.
-								apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, 1), requestFunction,	timeoutInMS));
+																								this.performGenericRetrieval(requestType, key, requestGenerator
+																									.
+																										apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, 1), requestFunction, timeoutInMS));
 
 		Flux<R> requestFlux = firstPage.map(page -> page.getTotalPages() - 1)
-				.flatMapMany(pagesCount -> Flux.range(2, pagesCount))
-				.map(pageNumber -> requestGenerator.apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, pageNumber));
+									   .flatMapMany(pagesCount -> Flux.range(2, pagesCount))
+									   .map(pageNumber -> requestGenerator.apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, pageNumber));
 
 		Mono<List<P>> subsequentPagesList = requestFlux.flatMap(req ->
-				this.performGenericRetrieval(requestType, key, req, requestFunction, timeoutInMS)).collectList();
+																	this.performGenericRetrieval(requestType, key, req, requestFunction, timeoutInMS))
+													   .collectList();
+
+		/*
+		 * Word on error handling: We can't judge here what will be the consequence, if
+		 * the first page could be retrieved properly, but retrieving some some later
+		 * page fails. The implication would depend on the consumer (whether incomplete
+		 * data was ok or not). So the safe answer here is to raise an error for the
+		 * entire request. That, however, is already in place with the error handling in
+		 * performGenericRetrieval: the stream is already in state "error" and thus will
+		 * not emit any item.
+		 */
+
+		return Mono.zip(firstPage, subsequentPagesList, Mono.just(reactiveTimer)).map(tuple -> {
+			P first = tuple.getT1();
+			List<P> subsequent = tuple.getT2();
+
+			List<S> ret = new LinkedList<>();
+
+			ret.addAll((List<? extends S>) first.getResources());
+			for (P listResponse : subsequent) {
+				ret.addAll((List<? extends S>) listResponse.getResources());
+			}
+
+			P retObject = responseGenerator.apply(ret, subsequent.size() + 1);
+
+			tuple.getT3().stop();
+
+			return retObject;
+		});
+	}
+
+	/**
+	 * performs a retrieval from the CF Cloud Controller fetching all pages available.
+	 *
+	 * @param requestType
+	 * 	the type information of the request which is being made
+	 * @param key
+	 * 	the key for which the request is being made (e.g. orgId, orgId|spaceName, ...)
+	 * @param requestGenerator
+	 * 	a request generator function, which permits creating request objects instance for a given set of page parameters (e.g. for which page, using
+	 * 	which page size, ...)
+	 * @param requestFunction
+	 * 	a function which calls the CF API operation, which is being made.
+	 * @param timeoutInMS
+	 * 	the timeout value in milliseconds for a single data request to the CF Cloud Controller
+	 * @param responseGenerator
+	 * 	a response generator function, which permits creating a response object, which contains the collected resources of all pages retrieved.
+	 *
+	 * @return a Mono on the response provided by the CF Cloud Controller
+	 */
+	public <S, P extends org.cloudfoundry.client.v3.PaginatedResponse<?>, R extends org.cloudfoundry.client.v3.PaginatedRequest> Mono<P> performGenericPagedRetrievalV3(
+		RequestType requestType, String key, PaginatedRequestGeneratorFunctionV3<R> requestGenerator,
+		Function<R, Mono<P>> requestFunction, int timeoutInMS,
+		PaginatedResponseGeneratorFunctionV3<S, P> responseGenerator) {
+
+		final String pageRetrievalType = requestType.getMetricName() + "_singlePage";
+
+		ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, pageRetrievalType);
+
+		Mono<P> firstPage = Mono.just(reactiveTimer).doOnNext(ReactiveTimer::start).flatMap(dummy ->
+																								this.performGenericRetrieval(requestType, key, requestGenerator
+																									.
+																										apply(RESULTS_PER_PAGE, 1), requestFunction, timeoutInMS));
+
+		Flux<R> requestFlux = firstPage.map(page -> page.getPagination().getTotalPages() - 1)
+									   .flatMapMany(pagesCount -> Flux.range(2, pagesCount))
+									   .map(pageNumber -> requestGenerator.apply(RESULTS_PER_PAGE, pageNumber));
+
+		Mono<List<P>> subsequentPagesList = requestFlux.flatMap(req ->
+																	this.performGenericRetrieval(requestType, key, req, requestFunction, timeoutInMS))
+													   .collectList();
 
 		/*
 		 * Word on error handling: We can't judge here what will be the consequence, if

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -6,6 +6,8 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -62,7 +64,47 @@ public class CFAccessorCacheCaffeineSpringApplication {
 		@Override
 		public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 			return Mono.just(ListOrganizationDomainsResponse.builder().build());
-		}		
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+			return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+			return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+			return Mono.just(GetSpaceResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+			return Mono.just(ListApplicationRoutesResponse.builder().build());
+		}
 
 		@Override
 		public void reset() {

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -93,7 +93,7 @@ public class CFAccessorCacheCaffeineSpringApplication {
 
 		@Override
 		public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
-			return Mono.just(GetSpaceResponse.builder().build());
+			return Mono.just(GetSpaceResponse.builder().id(spaceId).name("dummy").createdAt("time").build());
 		}
 
 		@Override

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
@@ -4,6 +4,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.JUnitTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,4 +105,61 @@ class CFAccessorCacheCaffeineTest {
 		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllDomains("dummy");
 	}
 
+	@Test
+	void testRetrieveOrgIdV3() throws InterruptedException {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response1 = subject.retrieveOrgIdV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveOrgIdV3("dummy");
+
+		Thread.sleep(10);
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response2 = subject.retrieveOrgIdV3("dummy");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveOrgIdV3("dummy");
+	}
+
+	@Test
+	void testRetrieveSpaceIdV3() {
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response1 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceIdV3("dummy1", "dummy2");
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response2 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceIdV3("dummy1", "dummy2");
+	}
+
+	@Test
+	void testRetrieveAllApplicationIdsInSpaceV3() {
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+	}
+
+	@Test
+	void testRetrieveAllOrgIdsV3() {
+		subject.retrieveAllOrgIdsV3();
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllOrgIdsV3();
+	}
+
+	@Test
+	void testRetrieveSpaceSummaryV3() {
+		Mono<GetSpaceResponse> response1 = subject.retrieveSpaceV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceV3("dummy");
+
+		Mono<GetSpaceResponse> response2 = subject.retrieveSpaceV3("dummy");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceV3("dummy");
+	}
+
+	@Test
+	void testRetrieveDomainV3() {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response1 = subject.retrieveAllDomainsV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllDomainsV3("dummy");
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response2 = subject.retrieveAllDomainsV3("dummy");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllDomainsV3("dummy");
+	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
@@ -4,6 +4,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.JUnitTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,6 +92,57 @@ class CFAccessorCacheClassicTest {
 		Mono<ListOrganizationDomainsResponse> response2 = subject.retrieveAllDomains("dummy");
 		assertThat(response1).isEqualTo(response2);
 		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllDomains("dummy");
+	}
+
+	@Test
+	void testRetrieveDomainsV3() {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response1 = subject.retrieveAllDomainsV3("dummy");
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response2 = subject.retrieveAllDomainsV3("dummy");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllDomainsV3("dummy");
+	}
+
+	@Test
+	void testRetrieveSpaceSummaryV3() {
+		Mono<GetSpaceResponse> response1 = subject.retrieveSpaceV3("dummy");
+		Mono<GetSpaceResponse> response2 = subject.retrieveSpaceV3("dummy");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceV3("dummy");
+	}
+
+	@Test
+	void testRetrieveAllApplicationIdsInSpaceV3() {
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+	}
+
+	@Test
+	void testRetrieveOrgIdV3() {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response1 = subject.retrieveOrgIdV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveOrgIdV3("dummy");
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response2 = subject.retrieveOrgIdV3("dummy");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveOrgIdV3("dummy");
+	}
+
+	@Test
+	void testRetrieveSpaceIdV3() {
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response1 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceIdV3("dummy1", "dummy2");
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response2 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceIdV3("dummy1" ,"dummy2");
 	}
 
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -25,6 +25,8 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -194,5 +196,45 @@ public class CFAccessorMassMock implements CFAccessor {
 
 		ListOrganizationDomainsResponse response = ListOrganizationDomainsResponse.builder().addAllResources(domains).build();
 		return Mono.just(response);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -23,6 +23,9 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.applications.ApplicationState;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -42,7 +45,7 @@ public class CFAccessorMock implements CFAccessor {
 	public static final String UNITTEST_SHARED_DOMAIN_UUID = "be9b8696-2fa6-11e8-b467-0ed5f89f718b";
 	public static final String UNITTEST_SHARED_DOMAIN = "shared.domain.example.org";
 	public static final String UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID = "48ae5bb3-a625-4c16-9e30-e9a6b10ca1be";
-	public static final String UNITTEST_ADDITIONAL_SHARED_DOMAIN = "additionalSubdomain.shared.domain.example.org";	
+	public static final String UNITTEST_ADDITIONAL_SHARED_DOMAIN = "additionalSubdomain.shared.domain.example.org";
 
 	public static final String UNITTEST_INTERNAL_DOMAIN_UUID = "49225c7e-b4c3-45b2-b796-7bb9c64dc79d";
 	public static final String UNITTEST_INTERNAL_DOMAIN = "apps.internal";
@@ -52,7 +55,7 @@ public class CFAccessorMock implements CFAccessor {
 	public static final String UNITTEST_APP_INTERNAL_HOST = "internal-app";
 
 	public static final String CREATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";
-	public static final String UPDATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";	
+	public static final String UPDATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";
 
 	@Override
 	public Mono<ListOrganizationsResponse> retrieveOrgId(String orgName) {
@@ -60,26 +63,28 @@ public class CFAccessorMock implements CFAccessor {
 		if ("unittestorg".equalsIgnoreCase(orgName)) {
 
 			OrganizationResource or = OrganizationResource.builder()
-					.entity(OrganizationEntity.builder().name("unittestorg").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_ORG_UUID).build()
-					// Note that UpdatedAt is not set here, as this can also happen in real life!
-					).build();
+														  .entity(OrganizationEntity.builder().name("unittestorg").build())
+														  .metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_ORG_UUID).build()
+																	// Note that UpdatedAt is not set here, as this can also happen in real life!
+														  ).build();
 
 			List<org.cloudfoundry.client.v2.organizations.OrganizationResource> list = new LinkedList<>();
 			list.add(or);
 
 			ListOrganizationsResponse resp = org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse
-					.builder().addAllResources(list).build();
+				.builder().addAllResources(list).build();
 
 			return Mono.just(resp);
-		} else if ("doesnotexist".equals(orgName)) {
+		}
+		else if ("doesnotexist".equals(orgName)) {
 			return Mono.just(org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse.builder()
-					.resources(new ArrayList<>()).build());
-		} else if ("exception".equals(orgName)) {
+																							   .resources(new ArrayList<>()).build());
+		}
+		else if ("exception".equals(orgName)) {
 			return Mono.just(org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse.builder().build())
-					.map(x -> {
-						throw new Error("exception org name provided");
-					});
+					   .map(x -> {
+						   throw new Error("exception org name provided");
+					   });
 		}
 		Assertions.fail("Invalid OrgId request");
 		return null;
@@ -90,33 +95,37 @@ public class CFAccessorMock implements CFAccessor {
 		if (orgId.equals(UNITTEST_ORG_UUID)) {
 			if ("unittestspace".equalsIgnoreCase(spaceName)) {
 				SpaceResource sr = SpaceResource.builder().entity(SpaceEntity.builder().name("unittestspace").build())
-						.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID).build())
-						.build();
+												.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID).build())
+												.build();
 				List<SpaceResource> list = new LinkedList<>();
 				list.add(sr);
 				ListSpacesResponse resp = ListSpacesResponse.builder().addAllResources(list).build();
 				return Mono.just(resp);
-			} else if ("unittestspace-summarydoesnotexist".equals(spaceName)) {
+			}
+			else if ("unittestspace-summarydoesnotexist".equals(spaceName)) {
 				SpaceResource sr = SpaceResource.builder().entity(SpaceEntity.builder().name(spaceName).build())
-						.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP)
-								.id(UNITTEST_SPACE_UUID_DOESNOTEXIST).build())
-						.build();
+												.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP)
+																  .id(UNITTEST_SPACE_UUID_DOESNOTEXIST).build())
+												.build();
 				List<SpaceResource> list = new LinkedList<>();
 				list.add(sr);
 				ListSpacesResponse resp = ListSpacesResponse.builder().addAllResources(list).build();
 				return Mono.just(resp);
-			} else if ("unittestspace-summaryexception".equals(spaceName)) {
+			}
+			else if ("unittestspace-summaryexception".equals(spaceName)) {
 				SpaceResource sr = SpaceResource.builder().entity(SpaceEntity.builder().name(spaceName).build())
-						.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID_EXCEPTION)
-								.build())
-						.build();
+												.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID_EXCEPTION)
+																  .build())
+												.build();
 				List<SpaceResource> list = new LinkedList<>();
 				list.add(sr);
 				ListSpacesResponse resp = ListSpacesResponse.builder().addAllResources(list).build();
 				return Mono.just(resp);
-			} else if ("doesnotexist".equals(spaceName)) {
+			}
+			else if ("doesnotexist".equals(spaceName)) {
 				return Mono.just(ListSpacesResponse.builder().resources(new ArrayList<>()).build());
-			} else if ("exception".equals(spaceName)) {
+			}
+			else if ("exception".equals(spaceName)) {
 				return Mono.just(ListSpacesResponse.builder().build()).map(x -> {
 					throw new Error("exception space name provided");
 				});
@@ -133,28 +142,30 @@ public class CFAccessorMock implements CFAccessor {
 			List<ApplicationResource> list = new LinkedList<>();
 
 			ApplicationResource ar = ApplicationResource.builder()
-					.entity(ApplicationEntity.builder().name("testapp").state("STARTED").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP1_UUID).build())
-					.build();
+														.entity(ApplicationEntity.builder().name("testapp").state("STARTED").build())
+														.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP1_UUID).build())
+														.build();
 			list.add(ar);
 
 			ar = ApplicationResource.builder()
-					.entity(ApplicationEntity.builder().name("testapp2").state("STARTED").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID).build())
-					.build();
+									.entity(ApplicationEntity.builder().name("testapp2").state("STARTED").build())
+									.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID).build())
+									.build();
 			list.add(ar);
 
 			ar = ApplicationResource.builder()
-					.entity(ApplicationEntity.builder().name("internalapp").state("STARTED").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID).build())
-					.build();
+									.entity(ApplicationEntity.builder().name("internalapp").state("STARTED").build())
+									.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID).build())
+									.build();
 			list.add(ar);
 
 			ListApplicationsResponse resp = ListApplicationsResponse.builder().addAllResources(list).build();
 			return Mono.just(resp);
-		} else if (UNITTEST_SPACE_UUID_DOESNOTEXIST.equals(spaceId)) {
+		}
+		else if (UNITTEST_SPACE_UUID_DOESNOTEXIST.equals(spaceId)) {
 			return Mono.just(ListApplicationsResponse.builder().build());
-		} else if (UNITTEST_SPACE_UUID_EXCEPTION.equals(spaceId)) {
+		}
+		else if (UNITTEST_SPACE_UUID_EXCEPTION.equals(spaceId)) {
 			return Mono.just(ListApplicationsResponse.builder().build()).map(x -> {
 				throw new Error("exception on AllAppIdsInSpace");
 			});
@@ -170,47 +181,50 @@ public class CFAccessorMock implements CFAccessor {
 			List<SpaceApplicationSummary> list = new LinkedList<>();
 
 			Domain sharedDomain = Domain.builder().id(UNITTEST_SHARED_DOMAIN_UUID).name(UNITTEST_SHARED_DOMAIN).build();
-			Domain additionalSharedDomain = Domain.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).name(UNITTEST_ADDITIONAL_SHARED_DOMAIN).build();
+			Domain additionalSharedDomain = Domain.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
+												  .build();
 			Domain internalDomain = Domain.builder().id(UNITTEST_INTERNAL_DOMAIN_UUID).name(UNITTEST_INTERNAL_DOMAIN).build();
 
-			final String[] urls1 = { UNITTEST_APP1_HOST + "." + UNITTEST_SHARED_DOMAIN };
-			final Route[] routes1 = { Route.builder().domain(sharedDomain).host(UNITTEST_APP1_HOST).build() };
+			final String[] urls1 = {UNITTEST_APP1_HOST + "." + UNITTEST_SHARED_DOMAIN};
+			final Route[] routes1 = {Route.builder().domain(sharedDomain).host(UNITTEST_APP1_HOST).build()};
 			SpaceApplicationSummary sas = SpaceApplicationSummary.builder()
-					.id(UNITTEST_APP1_UUID)
-					.name("testapp")
-					.addAllRoutes(Arrays.asList(routes1))
-					.addAllUrls(Arrays.asList(urls1)).instances(2).build();
+																 .id(UNITTEST_APP1_UUID)
+																 .name("testapp")
+																 .addAllRoutes(Arrays.asList(routes1))
+																 .addAllUrls(Arrays.asList(urls1)).instances(2).build();
 			list.add(sas);
 
 			String additionalPath = "/additionalPath";
 
-			final String[] urls2 = { UNITTEST_APP2_HOST + "." + UNITTEST_SHARED_DOMAIN + additionalPath,
-					UNITTEST_APP2_HOST + "." + UNITTEST_ADDITIONAL_SHARED_DOMAIN + additionalPath };
-			final Route[] routes2 = { 
-					Route.builder().domain(sharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build(),		
-					Route.builder().domain(additionalSharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build() };
+			final String[] urls2 = {UNITTEST_APP2_HOST + "." + UNITTEST_SHARED_DOMAIN + additionalPath,
+				UNITTEST_APP2_HOST + "." + UNITTEST_ADDITIONAL_SHARED_DOMAIN + additionalPath};
+			final Route[] routes2 = {
+				Route.builder().domain(sharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build(),
+				Route.builder().domain(additionalSharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build()};
 			sas = SpaceApplicationSummary.builder()
-					.id(UNITTEST_APP2_UUID)
-					.name("testapp2")
-					.addAllRoutes(Arrays.asList(routes2))
-					.addAllUrls(Arrays.asList(urls2)).instances(1).build();
+										 .id(UNITTEST_APP2_UUID)
+										 .name("testapp2")
+										 .addAllRoutes(Arrays.asList(routes2))
+										 .addAllUrls(Arrays.asList(urls2)).instances(1).build();
 			list.add(sas);
 
-			final String[] urls3 = { UNITTEST_APP_INTERNAL_HOST + "." + UNITTEST_INTERNAL_DOMAIN };
-			final Route[] routes3 = { Route.builder().domain(internalDomain).host(UNITTEST_APP_INTERNAL_HOST).build() };
+			final String[] urls3 = {UNITTEST_APP_INTERNAL_HOST + "." + UNITTEST_INTERNAL_DOMAIN};
+			final Route[] routes3 = {Route.builder().domain(internalDomain).host(UNITTEST_APP_INTERNAL_HOST).build()};
 			sas = SpaceApplicationSummary.builder()
-					.id(UNITTEST_APP_INTERNAL_UUID)
-					.name("internalapp")
-					.addAllRoutes(Arrays.asList(routes3))
-					.addAllUrls(Arrays.asList(urls3)).instances(2).build();
+										 .id(UNITTEST_APP_INTERNAL_UUID)
+										 .name("internalapp")
+										 .addAllRoutes(Arrays.asList(routes3))
+										 .addAllUrls(Arrays.asList(urls3)).instances(2).build();
 			list.add(sas);
 
 			GetSpaceSummaryResponse resp = GetSpaceSummaryResponse.builder().addAllApplications(list).build();
 
 			return Mono.just(resp);
-		} else if (spaceId.equals(UNITTEST_SPACE_UUID_DOESNOTEXIST)) {
+		}
+		else if (spaceId.equals(UNITTEST_SPACE_UUID_DOESNOTEXIST)) {
 			return Mono.just(GetSpaceSummaryResponse.builder().build());
-		} else if (spaceId.equals(UNITTEST_SPACE_UUID_EXCEPTION)) {
+		}
+		else if (spaceId.equals(UNITTEST_SPACE_UUID_EXCEPTION)) {
 			return Mono.just(GetSpaceSummaryResponse.builder().build()).map(x -> {
 				throw new Error("exception on application summary");
 			});
@@ -232,7 +246,7 @@ public class CFAccessorMock implements CFAccessor {
 	@Override
 	public Mono<GetInfoResponse> getInfo() {
 		GetInfoResponse data = GetInfoResponse.builder().description("CFAccessorMock").name("CFAccessorMock").version(1)
-				.build();
+											  .build();
 
 		return Mono.just(data);
 	}
@@ -243,46 +257,230 @@ public class CFAccessorMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {		
+	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 		List<DomainResource> domains = new ArrayList<DomainResource>();
 		DomainResource domain = DomainResource.builder()
-				.entity(
-					DomainEntity.builder()
-					.name(UNITTEST_INTERNAL_DOMAIN)
-					.internal(true)
-					.build())
-				.metadata(
-					Metadata.builder().id(UNITTEST_INTERNAL_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())    
-				.build();
+											  .entity(
+												  DomainEntity.builder()
+															  .name(UNITTEST_INTERNAL_DOMAIN)
+															  .internal(true)
+															  .build())
+											  .metadata(
+												  Metadata.builder().id(UNITTEST_INTERNAL_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())
+											  .build();
 
 		domains.add(domain);
 
 		domain = DomainResource.builder()
-				.entity(
-					DomainEntity.builder()
-					.name(UNITTEST_SHARED_DOMAIN)
-					.internal(false)
-					.build())
-				.metadata(
-					Metadata.builder().id(UNITTEST_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())    
-				.build();
+							   .entity(
+								   DomainEntity.builder()
+											   .name(UNITTEST_SHARED_DOMAIN)
+											   .internal(false)
+											   .build())
+							   .metadata(
+								   Metadata.builder().id(UNITTEST_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())
+							   .build();
 
 		domains.add(domain);
 
 		domain = DomainResource.builder()
-				.entity(
-					DomainEntity.builder()
-					.name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
-					.internal(false)
-					.build())
-				.metadata(
-					Metadata.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())    
-				.build();
+							   .entity(
+								   DomainEntity.builder()
+											   .name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
+											   .internal(false)
+											   .build())
+							   .metadata(
+								   Metadata.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())
+							   .build();
 
 		domains.add(domain);
 
 		ListOrganizationDomainsResponse response = ListOrganizationDomainsResponse.builder().addAllResources(domains).build();
 		return Mono.just(response);
 	}
-	
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		if ("unittestorg".equalsIgnoreCase(orgName)) {
+
+			org.cloudfoundry.client.v3.organizations.OrganizationResource or = org.cloudfoundry.client.v3.organizations.OrganizationResource.builder()
+																																			.name("unittestorg")
+																																			.createdAt(CREATED_AT_TIMESTAMP)
+																																			.id(UNITTEST_ORG_UUID)
+																																			// Note that UpdatedAt is not set here, as this can also happen in real life!
+																																			.build();
+
+			List<org.cloudfoundry.client.v3.organizations.OrganizationResource> list = new LinkedList<>();
+			list.add(or);
+
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse resp = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+				.builder().addAllResources(list).build();
+
+			return Mono.just(resp);
+		}
+		else if ("doesnotexist".equals(orgName)) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+																							   .resources(new ArrayList<>()).build());
+		}
+		else if ("exception".equals(orgName)) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build())
+					   .map(x -> {
+						   throw new Error("exception org name provided");
+					   });
+		}
+		Assertions.fail("Invalid OrgId request");
+		return null;
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		return this.retrieveOrgIdV3("unittestorg");
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		if (orgId.equals(UNITTEST_ORG_UUID)) {
+			if ("unittestspace".equalsIgnoreCase(spaceName)) {
+				org.cloudfoundry.client.v3.spaces.SpaceResource sr = org.cloudfoundry.client.v3.spaces.SpaceResource.builder().name("unittestspace")
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.id(UNITTEST_SPACE_UUID)
+																													.build();
+				List<org.cloudfoundry.client.v3.spaces.SpaceResource> list = new LinkedList<>();
+				list.add(sr);
+				org.cloudfoundry.client.v3.spaces.ListSpacesResponse resp = org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+																																.addAllResources(list)
+																																.build();
+				return Mono.just(resp);
+			}
+			else if ("unittestspace-summarydoesnotexist".equals(spaceName)) {
+				org.cloudfoundry.client.v3.spaces.SpaceResource sr = org.cloudfoundry.client.v3.spaces.SpaceResource.builder().name(spaceName)
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.id(UNITTEST_SPACE_UUID_DOESNOTEXIST)
+																													.build();
+				List<org.cloudfoundry.client.v3.spaces.SpaceResource> list = new LinkedList<>();
+				list.add(sr);
+				org.cloudfoundry.client.v3.spaces.ListSpacesResponse resp = org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+																																.addAllResources(list)
+																																.build();
+				return Mono.just(resp);
+			}
+			else if ("unittestspace-summaryexception".equals(spaceName)) {
+				org.cloudfoundry.client.v3.spaces.SpaceResource sr = org.cloudfoundry.client.v3.spaces.SpaceResource.builder().name(spaceName)
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.id(UNITTEST_SPACE_UUID_EXCEPTION)
+																													.build();
+				List<org.cloudfoundry.client.v3.spaces.SpaceResource> list = new LinkedList<>();
+				list.add(sr);
+				org.cloudfoundry.client.v3.spaces.ListSpacesResponse resp = org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+																																.addAllResources(list)
+																																.build();
+				return Mono.just(resp);
+			}
+			else if ("doesnotexist".equals(spaceName)) {
+				return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().resources(new ArrayList<>()).build());
+			}
+			else if ("exception".equals(spaceName)) {
+				return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().build()).map(x -> {
+					throw new Error("exception space name provided");
+				});
+			}
+		}
+
+		Assertions.fail("Invalid SpaceId request");
+		return null;
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		return this.retrieveSpaceIdV3(UNITTEST_ORG_UUID, "unittestspace");
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		if (orgId.equals(UNITTEST_ORG_UUID) && spaceId.equals(UNITTEST_SPACE_UUID)) {
+			List<org.cloudfoundry.client.v3.applications.ApplicationResource> list = new LinkedList<>();
+
+			org.cloudfoundry.client.v3.applications.ApplicationResource ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
+																																		.name("testapp")
+																																		.state(ApplicationState.STARTED)
+																																		.createdAt(CREATED_AT_TIMESTAMP)
+																																		.id(UNITTEST_APP1_UUID)
+																																		.build();
+			list.add(ar);
+
+			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
+																			.name("testapp2").state(ApplicationState.STARTED)
+																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID)
+																			.build();
+			list.add(ar);
+
+			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
+																			.name("internalapp").state(ApplicationState.STARTED)
+																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID)
+																			.build();
+			list.add(ar);
+
+			org.cloudfoundry.client.v3.applications.ListApplicationsResponse resp = org.cloudfoundry.client.v3.applications.ListApplicationsResponse
+				.builder().addAllResources(list).build();
+			return Mono.just(resp);
+		}
+		else if (UNITTEST_SPACE_UUID_DOESNOTEXIST.equals(spaceId)) {
+			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build());
+		}
+		else if (UNITTEST_SPACE_UUID_EXCEPTION.equals(spaceId)) {
+			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build()).map(x -> {
+				throw new Error("exception on AllAppIdsInSpace");
+			});
+		}
+
+		Assertions.fail("Invalid process request");
+		return null;
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// This API has drastically changed in v3 and does not support the same resources. This call for a space summary will probably
+		// take another call to list applications for a space, list routes for the apps, and list domains in the org
+		// Previously they were all grouped into this API
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		List<org.cloudfoundry.client.v3.domains.DomainResource> domains = new ArrayList<>();
+		org.cloudfoundry.client.v3.domains.DomainResource domain = org.cloudfoundry.client.v3.domains.DomainResource.builder()
+																													.name(UNITTEST_INTERNAL_DOMAIN)
+																													.isInternal(true)
+																													.id(UNITTEST_INTERNAL_DOMAIN_UUID)
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.build();
+
+		domains.add(domain);
+
+		domain = org.cloudfoundry.client.v3.domains.DomainResource.builder()
+																  .name(UNITTEST_SHARED_DOMAIN)
+																  .isInternal(false)
+																  .id(UNITTEST_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP)
+																  .build();
+
+		domains.add(domain);
+
+		domain = org.cloudfoundry.client.v3.domains.DomainResource.builder()
+																  .name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
+																  .isInternal(false)
+																  .id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP)
+																  .build();
+
+		domains.add(domain);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse
+			.builder().addAllResources(domains).build();
+		return Mono.just(response);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
+	}
+
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeoutException;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsRequest;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.organizations.OrganizationResource;
+import org.cloudfoundry.client.v3.Metadata;
+import org.cloudfoundry.client.v3.Pagination;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,199 +20,301 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 class ReactiveCFPaginatedRequestFetcherTest {
-	
+
 	private InternalMetrics internalMetricsMocked = Mockito.mock(InternalMetrics.class);
-	
+
 	private static PaginatedRequestGeneratorFunction<ListOrganizationsRequest> requestGenerator;
 	private static PaginatedResponseGeneratorFunction<OrganizationResource, ListOrganizationsResponse> responseGenerator;
-	
+	private static PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest> requestGeneratorV3;
+	private static PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.OrganizationResource, org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> responseGeneratorV3;
+
 	static {
 		requestGenerator = (orderDirection, resultsPerPage, pageNumber) ->
-				ListOrganizationsRequest.builder()
-				.orderDirection(orderDirection)
-				.resultsPerPage(resultsPerPage)
-				.page(pageNumber)
-				.build();
+			ListOrganizationsRequest.builder()
+									.orderDirection(orderDirection)
+									.resultsPerPage(resultsPerPage)
+									.page(pageNumber)
+									.build();
+
+		requestGeneratorV3 = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder()
+																			 .perPage(resultsPerPage)
+																			 .page(pageNumber)
+																			 .build();
 
 		responseGenerator = (data, numberOfPages) ->
-				ListOrganizationsResponse.builder()
-				.resources(data)
-				.totalPages(numberOfPages)
-				.totalResults(data.size())
-				.build();
+			ListOrganizationsResponse.builder()
+									 .resources(data)
+									 .totalPages(numberOfPages)
+									 .totalResults(data.size())
+									 .build();
+
+		responseGeneratorV3 = (data, numberOfPages) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+																			  .resources(data)
+																			  .pagination(Pagination.builder().totalPages(numberOfPages)
+																									.totalResults(data.size()).build())
+																			  .build();
 
 	}
-	
+
 	@Test
 	void testEmptyResponse() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(new LinkedList<>())
-					.totalPages(1)
-					.totalResults(0)
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(new LinkedList<>())
+																			  .totalPages(1)
+																			  .totalResults(0)
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
 		Assertions.assertEquals(1, subjectResponse.getTotalPages().intValue());
 		Assertions.assertEquals(0, subjectResponse.getTotalResults().intValue());
 		Assertions.assertNotNull(subjectResponse.getResources());
-		Assertions.assertTrue (subjectResponse.getResources().isEmpty());
+		Assertions.assertTrue(subjectResponse.getResources().isEmpty());
 	}
-	
+
+	@Test
+	void testEmptyResponseV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request -> {
+				org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+					.builder()
+					.resources(new LinkedList<>())
+					.pagination(Pagination.builder().totalPages(1)
+										  .totalResults(0).build())
+					.build();
+
+				return Mono.just(response);
+			}, 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(1, subjectResponse.getPagination().getTotalPages().intValue());
+		Assertions.assertEquals(0, subjectResponse.getPagination().getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertTrue(subjectResponse.getResources().isEmpty());
+	}
+
 	@Test
 	void testWithContentOnePage() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			list.add(OrganizationResource.builder().build());
-			list.add(OrganizationResource.builder().build());
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(1)
-					.totalResults(2)
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+				list.add(OrganizationResource.builder().build());
+				list.add(OrganizationResource.builder().build());
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(1)
+																			  .totalResults(2)
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
 		Assertions.assertEquals(1, subjectResponse.getTotalPages().intValue());
 		Assertions.assertEquals(2, subjectResponse.getTotalResults().intValue());
-		Assertions.assertNotNull (subjectResponse.getResources());
+		Assertions.assertNotNull(subjectResponse.getResources());
 		Assertions.assertEquals(2, subjectResponse.getResources().size());
 	}
-	
+
+	@Test
+	void testWithContentOnePageV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request -> {
+				LinkedList<org.cloudfoundry.client.v3.organizations.OrganizationResource> list = new LinkedList<>();
+				list.add(org.cloudfoundry.client.v3.organizations.OrganizationResource.builder().createdAt("").id("").metadata(Metadata.builder().build()).name("").build());
+				list.add(org.cloudfoundry.client.v3.organizations.OrganizationResource.builder().createdAt("").id("").metadata(Metadata.builder().build()).name("").build());
+
+				org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .pagination(Pagination.builder().totalPages(1)
+																									.totalResults(0).build())
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(1, subjectResponse.getPagination().getTotalPages().intValue());
+		Assertions.assertEquals(2, subjectResponse.getPagination().getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(2, subjectResponse.getResources().size());
+	}
+
 	@Test
 	void testWithContentTwoPages() {
 		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, 0, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			
-			for (int i = 0;i<request.getResultsPerPage(); i++) {
-				list.add(OrganizationResource.builder().build());
-			}
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(2)
-					.totalResults(2 * request.getResultsPerPage())
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
-		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
-		Assertions.assertEquals(2, subjectResponse.getTotalPages().intValue());
-		Assertions.assertEquals(2*100, subjectResponse.getTotalResults().intValue());
-		Assertions.assertNotNull(subjectResponse.getResources());
-		Assertions.assertEquals(2*100, subjectResponse.getResources().size());
-	}
-	
-	@Test
-	void testWithContentTwoPagesSecondWithoutItems() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			
-			if (request.getPage() == 1) {
-				for (int i = 0;i<request.getResultsPerPage(); i++) {
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+
+				for (int i = 0; i < request.getResultsPerPage(); i++) {
 					list.add(OrganizationResource.builder().build());
 				}
-			}
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(2)
-					.totalResults( (2 - request.getPage()) * request.getResultsPerPage()) // that's tricky&ugly, but correct: It would be the answer, if suddenly the items on the 2nd page vanished
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(2)
+																			  .totalResults(2 * request.getResultsPerPage())
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
 		Assertions.assertEquals(2, subjectResponse.getTotalPages().intValue());
-		Assertions.assertEquals(1*100, subjectResponse.getTotalResults().intValue());
-		Assertions.assertNotNull (subjectResponse.getResources());
-		Assertions.assertEquals(1*100, subjectResponse.getResources().size());
+		Assertions.assertEquals(2 * 100, subjectResponse.getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(2 * 100, subjectResponse.getResources().size());
 	}
-	
+
+	@Test
+	void testWithContentTwoPagesSecondWithoutItems() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+
+				if (request.getPage() == 1) {
+					for (int i = 0; i < request.getResultsPerPage(); i++) {
+						list.add(OrganizationResource.builder().build());
+					}
+				}
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(2)
+																			  .totalResults((2 - request.getPage()) * request
+																				  .getResultsPerPage()) // that's tricky&ugly, but correct: It would be the answer, if suddenly the items on the 2nd page vanished
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
+		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(2, subjectResponse.getTotalPages().intValue());
+		Assertions.assertEquals(1 * 100, subjectResponse.getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(1 * 100, subjectResponse.getResources().size());
+	}
+
 	@Test
 	void testWithContentTimeoutOnFirstPage() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
 				Mono.error(new TimeoutException()), 100, responseGenerator);
-		
+
 		ListOrganizationsResponse fallback = ListOrganizationsResponse.builder().build();
-		
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
-			Assertions.assertTrue(Exceptions.unwrap(e) instanceof TimeoutException)
+																					  Assertions.assertTrue(Exceptions
+																												.unwrap(e) instanceof TimeoutException)
 		).onErrorReturn(fallback).block();
 		Assertions.assertEquals(fallback, subjectResponse);
 	}
-	
+
+	@Test
+	void testWithContentTimeoutOnFirstPageV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request ->
+				Mono.error(new TimeoutException()), 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse fallback = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+			.builder().build();
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
+																															   Assertions
+																																   .assertTrue(Exceptions
+																																				   .unwrap(e) instanceof TimeoutException)
+		).onErrorReturn(fallback).block();
+		Assertions.assertEquals(fallback, subjectResponse);
+	}
+
 	@Test
 	void testWithContentTimeoutOnSecondPage() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			if (request.getPage() == 2) {
-				return Mono.error(new TimeoutException());
-			}
-			
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			
-			if (request.getPage() == 1) {
-				for (int i = 0;i<request.getResultsPerPage(); i++) {
-					list.add(OrganizationResource.builder().build());
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				if (request.getPage() == 2) {
+					return Mono.error(new TimeoutException());
 				}
-			}
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(2)
-					.totalResults(2 * request.getResultsPerPage()) 
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+
+				if (request.getPage() == 1) {
+					for (int i = 0; i < request.getResultsPerPage(); i++) {
+						list.add(OrganizationResource.builder().build());
+					}
+				}
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(2)
+																			  .totalResults(2 * request.getResultsPerPage())
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse fallback = ListOrganizationsResponse.builder().build();
-		
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
-			Assertions.assertTrue(Exceptions.unwrap(e) instanceof TimeoutException)
+																					  Assertions.assertTrue(Exceptions
+																												.unwrap(e) instanceof TimeoutException)
 		).onErrorReturn(fallback).block();
 		Assertions.assertEquals(fallback, subjectResponse);
 	}
 
 	@Test
 	void testWithContentGeneralException() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
-			Mono.error(new Exception()), 100, responseGenerator);
-		
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
+				Mono.error(new Exception()), 100, responseGenerator);
+
 		ListOrganizationsResponse fallback = ListOrganizationsResponse.builder().build();
-		
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
-			Assertions.assertTrue(Exceptions.unwrap(e) instanceof Exception)
+																					  Assertions.assertTrue(Exceptions.unwrap(e) instanceof Exception)
 		).onErrorReturn(fallback).block();
 		Assertions.assertEquals(fallback, subjectResponse);
 	}
-	
+
 	@Test
 	void testInfiniteRateLimitPossible() {
 		RateLimiter rl = RateLimiter.create(Double.POSITIVE_INFINITY);
-		
+
 		boolean acquired = rl.tryAcquire(10000, Duration.ofMillis(100));
 		Assertions.assertTrue(acquired);
 	}


### PR DESCRIPTION
**This PR is a WIP, additional tests are being added.**

Since the CFAccessor has return types that depend on the V2 API, I have added v3 API methods to it instead of a V3 implementation.
This still allows different types of accessors (ex: caching) to implement the response of the V3 APIs but makes it easier to integrate alongside V2.

VITE-1251
