### PR TITLE
Implement Kubernetes Prometheus annotation filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Here is the list of major features provided by Promregator:
 * [Additional metrics are provided](docs/enrichment.md) supporting you to **monitor Promregator** and the **communication to the Cloud Foundry applications**.
 * *(>= 0.4.0)* **[Cache Invalidation](docs/invalidate-cache.md)** is possible via an (optionally auth-protected) HTTP REST endpoint.
 * Promregator's endpoints (e.g. `/metrics`, `/promregatorMetrics`, `/discovery`) support **GZIP compression**, if the clients indicates to accept it.
+* Filtering by annotations and using annotations to specify the metrics path.
 
 
 ## Architecture

--- a/docs/config.md
+++ b/docs/config.md
@@ -429,6 +429,16 @@ Defaults to `/metrics`, as this is the value which is suggested by Prometheus.
 
 Note that there may be frameworks out there, which expose their metrics in a different format using the same path `/metrics`, though. 
 
+#### Item property "promregator.targets[].kubernetesAnnotations" (optional)
+Enables support for the de facto standard Kubernetes Prometheus annotations on your CF applications. This allows each application to "opt-in" to scraping
+by specifying the annotation `prometheus.io/scrape: "true"`. Annotations support requires a version of Cloud Foundry with the V3 API otherwise this setting will be ignored. 
+
+For an example on deploying an app with these annotations see [here](https://github.com/cloudfoundry/cf-for-k8s-metric-examples).
+
+Defaults to `false`. Enabling this feature will override the `promregator.targets[].path` when it is specified using the annotation `prometheus.io/path: "/some/other/metrics"`
+
+Does not currently support the `prometheus.io/port` annotation.
+
 #### Item property "promregator.targets[].protocol" (optional)
 Specifies the protocol (`http` or `https`) which shall be used to retrieve the metrics.
 

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -35,7 +35,7 @@ public interface CFAccessor {
 
 	Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId);
 
-	Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId);
+	Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId);
 
 	Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId);
 

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -30,6 +30,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	private AutoRefreshingCacheMap<CacheKeyAppsInSpace, Mono<ListApplicationsResponse>> appsInSpaceCache;
 	private AutoRefreshingCacheMap<String, Mono<GetSpaceSummaryResponse>> spaceSummaryCache;	
 	private AutoRefreshingCacheMap<String, Mono<ListOrganizationDomainsResponse>> domainCache;
+	private AutoRefreshingCacheMap<CacheKeyAppsInSpace, Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse>> appsInSpaceV3Cache;
 
 	@Value("${cf.cache.timeout.org:3600}")
 	private int refreshCacheOrgLevelInSeconds;
@@ -79,6 +80,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 		this.appsInSpaceCache = new AutoRefreshingCacheMap<>("appsInSpace", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::appsInSpaceCacheLoader);
 		this.spaceSummaryCache = new AutoRefreshingCacheMap<>("spaceSummary", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::spaceSummaryCacheLoader);		
 		this.domainCache = new AutoRefreshingCacheMap<>("routeMappings", this.internalMetrics, Duration.ofSeconds(this.expiryCacheDomainLevelInSeconds), Duration.ofSeconds(refreshCacheDomainLevelInSeconds), this::domainCacheLoader);
+		this.appsInSpaceV3Cache = new AutoRefreshingCacheMap<>("appsInSpaceV3", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::appsInSpaceV3CacheLoader);
 	}
 
 	private Mono<ListOrganizationsResponse> orgCacheLoader(String orgName) {
@@ -399,6 +401,70 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 		return mono;
   	}
 
+	private Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> appsInSpaceV3CacheLoader(CacheKeyAppsInSpace cacheKey) {
+		Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> mono = this.parent.retrieveAllApplicationsInSpaceV3(cacheKey.getOrgId(), cacheKey.getSpaceId()).cache();
+
+
+		/*
+		 * Note that the mono does not have any subscriber, yet!
+		 * The cache which we are using is working "on-stock", i.e. we need to ensure
+		 * that the underlying calls to the CF API really is triggered.
+		 * Fortunately, we can do this very easily:
+		 */
+		mono.subscribe();
+
+		/*
+		 * Handling for issue #96: If a timeout of the request to the  CF Cloud Controller occurs,
+		 * we must make sure that the erroneous Mono is not kept in the cache. Instead we have to displace the item,
+		 * which triggers a refresh of the cache.
+		 *
+		 * Note that subscribe() must be called *before* adding this error handling below.
+		 * Otherwise we will run into the situation that the error handling routine is called by this
+		 * subscribe() already - but the Mono has not been written into the cache yet!
+		 * If we do it in this order, the doOnError method will only be called once the first "real subscriber"
+		 * of the Mono will start requesting.
+		 */
+		mono = mono.doOnError(e -> {
+			if (e instanceof TimeoutException) {
+				log.warn(String.format("Timed-out entry using key %s detected, which would get stuck in our appsInSpace cache; "
+										   + "displacing it now to prevent further harm", cacheKey), e);
+				/*
+				 * Note that it *might* happen that a different Mono gets displaced than the one we are in here now.
+				 * Yet, we can't make use of the
+				 *
+				 * remove(key, value)
+				 *
+				 * method, as providing value would lead to a hen-egg problem (we were required to provide the reference
+				 * of the Mono instance, which we are just creating).
+				 * Instead, we just blindly remove the entry from the cache. This may lead to four cases to consider:
+				 *
+				 * 1. We hit the correct (erroneous) entry: then this is exactly what we want to do.
+				 * 2. We hit another erroneous entry: then we have no harm done, because we fixed yet another case.
+				 * 3. We hit a healthy entry: Bad luck; on next iteration, we will get a cache miss, which automatically
+				 *    fixes the issue (as long this does not happen too often, ...)
+				 * 4. The entry has already been deleted by someone else: the remove(key) operation will
+				 *    simply be a NOOP. => no harm done either.
+				 */
+				this.appsInSpaceV3Cache.remove(cacheKey);
+
+				// Notify metrics of this case
+				if (this.internalMetrics != null) {
+					this.internalMetrics.countAutoRefreshingCacheMapErroneousEntriesDisplaced(this.appsInSpaceV3Cache.getName());
+				}
+			}
+		});
+		/*
+		 * Keep in mind that doOnError is a side-effect:  The logic above only removes it from the cache.
+		 * The erroneous instance still is used downstream and will trigger subsequent error handling (including
+		 * logging) there.
+		 * Note that this also holds true during the timeframe of the timeout: This instance of the Mono will
+		 * be written to the cache, thus all consumers of the cache will be handed out the cached, not-yet-resolved
+		 * object instance. This implicitly makes sure that there can only be one valid pending request is out there.
+		 */
+
+		return mono;
+	}
+
 
 	@Override
 	public Mono<GetInfoResponse> getInfo() {
@@ -479,9 +545,10 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
-		// TODO: Implement cache
-		return this.parent.retrieveAllApplicationIdsInSpaceV3(orgId, spaceId);
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
+		final CacheKeyAppsInSpace key = new CacheKeyAppsInSpace(orgId, spaceId);
+
+		return this.appsInSpaceV3Cache.get(key);
 	}
 
 	@Override
@@ -505,6 +572,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	public void invalidateCacheApplications() {
 		log.info("Invalidating application cache");
 		this.spaceSummaryCache.clear();
+		this.appsInSpaceV3Cache.clear();
 		// TODO why is appsInSpaceCache not cleared here?
 	}
 	

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -31,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
+import static org.cloudfoundry.promregator.cfaccessor.ReactiveCFAccessorImpl.INVALID_APPLICATIONS_RESPONSE;
+
 public class CFAccessorSimulator implements CFAccessor {
 	public static final String ORG_UUID = "eb51aa9c-2fa3-11e8-b467-0ed5f89f718b";
 	public static final String SPACE_UUID = "db08be9a-2fa4-11e8-b467-0ed5f89f718b";
@@ -245,8 +247,8 @@ public class CFAccessorSimulator implements CFAccessor {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
-		throw new UnsupportedOperationException();
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
+		return Mono.just(INVALID_APPLICATIONS_RESPONSE);
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -233,7 +233,7 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 		// Ensures v3 API exists. The CF Java Client does not yet implement the info endpoint for V3, so we do it manually.
 		JsonNode v3Info = new ReactorInfoV3(this.cloudFoundryClient.getConnectionContext(), this.cloudFoundryClient.getRootV3(),
 											this.cloudFoundryClient.getTokenProvider(), this.cloudFoundryClient.getRequestTags())
-			.get(null).onErrorReturn(JsonNodeFactory.instance.nullNode()).block();
+			.get().onErrorReturn(JsonNodeFactory.instance.nullNode()).block();
 
 		if (v3Info == null || v3Info.isNull()) {
 			log.warn("unable to get v3 info endpoint of CF platform");

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -7,6 +7,8 @@ import java.util.regex.Pattern;
 
 import javax.annotation.PostConstruct;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.apache.http.conn.util.InetAddressUtils;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
 import org.cloudfoundry.client.v2.applications.ListApplicationsRequest;
@@ -27,6 +29,7 @@ import org.cloudfoundry.client.v3.Pagination;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.spaces.GetSpaceRequest;
 import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
+import org.cloudfoundry.promregator.cfaccessor.client.ReactorInfoV3;
 import org.cloudfoundry.promregator.config.ConfigurationException;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.cloudfoundry.reactor.ConnectionContext;
@@ -47,6 +50,7 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	private static final Logger log = LoggerFactory.getLogger(ReactiveCFAccessorImpl.class);
 	private boolean v3Enabled;
+	public static org.cloudfoundry.client.v3.applications.ListApplicationsResponse INVALID_APPLICATIONS_RESPONSE = org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build();
 
 	@Value("${cf.api_host}")
 	private String apiHost;
@@ -226,12 +230,16 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 			log.info("Target CF platform is running on API version {}", apiVersion);
 		}
 
-		String getRoot = this.cloudFoundryClient.getRootV3().block();
-		// Ensures v3 API exists
+		// Ensures v3 API exists. The CF Java Client does not yet implement the info endpoint for V3, so we do it manually.
+		JsonNode v3Info = new ReactorInfoV3(this.cloudFoundryClient.getConnectionContext(), this.cloudFoundryClient.getRootV3(),
+											this.cloudFoundryClient.getTokenProvider(), this.cloudFoundryClient.getRequestTags())
+			.get(null).onErrorReturn(JsonNodeFactory.instance.nullNode()).block();
 
-		if (getRoot == null) {
-			log.warn("unable to get v3 endpoint of CF platform");
+		if (v3Info == null || v3Info.isNull()) {
+			log.warn("unable to get v3 info endpoint of CF platform");
 			this.v3Enabled = false;
+		} else {
+			this.v3Enabled = true;
 		}
 	}
 
@@ -412,6 +420,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	@Override
 	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		if (!isV3Enabled()) {
+			throw new UnsupportedOperationException("V3 API is not supported on your foundation.");
+		}
+
 		// Note: even though we use the List request here, the number of values returned is either zero or one
 		// ==> No need for a paged request.
 		org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest orgsRequest = org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder().name(orgName).build();
@@ -423,6 +435,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	@Override
 	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		if (!isV3Enabled()) {
+			throw new UnsupportedOperationException("V3 API is not supported on your foundation.");
+		}
+
 		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest> requestGenerator = (resultsPerPage, pageNumber) ->
 			org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder()
 									.perPage(resultsPerPage)
@@ -441,6 +457,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	@Override
 	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		if (!isV3Enabled()) {
+			throw new UnsupportedOperationException("V3 API is not supported on your foundation.");
+		}
+
 		// Note: even though we use the List request here, the number of values returned is either zero or one
 		// ==> No need for a paged request.
 
@@ -455,6 +475,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	@Override
 	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		if (!isV3Enabled()) {
+			throw new UnsupportedOperationException("V3 API is not supported on your foundation.");
+		}
+
 		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.spaces.ListSpacesRequest> requestGenerator = (resultsPerPage, pageNumber) ->
 			org.cloudfoundry.client.v3.spaces.ListSpacesRequest.builder()
 							 .organizationId(orgId)
@@ -474,7 +498,11 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
+		if (!isV3Enabled()) {
+			return Mono.just(INVALID_APPLICATIONS_RESPONSE);
+		}
+
 		String key = String.format("%s|%s", orgId, spaceId);
 
 		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.applications.ListApplicationsRequest> requestGenerator = (resultsPerPage, pageNumber) ->
@@ -497,6 +525,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	@Override
 	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		if (!isV3Enabled()) {
+			throw new UnsupportedOperationException("V3 API is not supported on your foundation.");
+		}
+
 		// This API has drastically changed in v3 and does not support the same resources. This call for a space summary will probably
 		// take another call to list applications for a space, list routes for the apps, and list domains in the org
 		// Previously they were all grouped into this API
@@ -509,6 +541,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	@Override
 	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		if (!isV3Enabled()) {
+			throw new UnsupportedOperationException("V3 API is not supported on your foundation.");
+		}
+
 		org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsRequest request = org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsRequest.builder().organizationId(orgId).build();
 
 		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, orgId,

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
@@ -1,0 +1,26 @@
+package org.cloudfoundry.promregator.cfaccessor.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+/**
+ * Call the v3 info API and returns a JsonNode. Since we do not care about the actual response (other than errors), we do not need to
+ * model the whole response object.
+ * Issue: https://github.com/cloudfoundry/cf-java-client/issues/1097
+ */
+public class ReactorInfoV3 extends AbstractClientV3Operations {
+
+	public ReactorInfoV3(ConnectionContext connectionContext, Mono<String> root, TokenProvider tokenProvider, Map<String, String> requestTags) {
+		super(connectionContext, root, tokenProvider, requestTags);
+	}
+
+	public Mono<JsonNode> get(Object request) {
+		return get(request, JsonNode.class, builder -> builder.pathSegment("info"))
+			.checkpoint();
+	}
+}

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
@@ -19,8 +19,8 @@ public class ReactorInfoV3 extends AbstractClientV3Operations {
 		super(connectionContext, root, tokenProvider, requestTags);
 	}
 
-	public Mono<JsonNode> get(Object request) {
-		return get(request, JsonNode.class, builder -> builder.pathSegment("info"))
+	public Mono<JsonNode> get() {
+		return get(null, JsonNode.class, builder -> builder.pathSegment("info"))
 			.checkpoint();
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
@@ -20,7 +20,7 @@ public class ReactorInfoV3 extends AbstractClientV3Operations {
 	}
 
 	public Mono<JsonNode> get() {
-		return get(null, JsonNode.class, builder -> builder.pathSegment("info"))
+		return get("", JsonNode.class, builder -> builder.pathSegment("info"))
 			.checkpoint();
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/config/Target.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/Target.java
@@ -28,6 +28,8 @@ public class Target {
 
 	private String path;
 
+	private Boolean kubernetesAnnotations = false;
+
 	private String protocol;
 
 	private String authenticatorId;
@@ -62,6 +64,9 @@ public class Target {
 		this.applicationName = source.applicationName;
 		this.applicationRegex = source.applicationRegex;
 		this.path = source.path;
+		if (source.kubernetesAnnotations != null)
+			this.kubernetesAnnotations = source.kubernetesAnnotations;
+
 		this.protocol = source.protocol;
 		this.authenticatorId = source.authenticatorId;
 		this.internalRoutePort = source.internalRoutePort;
@@ -131,6 +136,14 @@ public class Target {
 
 	public void setPath(String path) {
 		this.path = path;
+	}
+
+	public Boolean getKubernetesAnnotations() {
+		return kubernetesAnnotations;
+	}
+
+	public void setKubernetesAnnotations(Boolean kubernetesAnnotations) {
+		this.kubernetesAnnotations = kubernetesAnnotations != null ? kubernetesAnnotations : false;
 	}
 
 	public String getProtocol() {
@@ -223,6 +236,8 @@ public class Target {
 		builder.append(applicationRegex);
 		builder.append(", path=");
 		builder.append(path);
+		builder.append(", kubernetesAnnotations=");
+		builder.append(kubernetesAnnotations.toString());
 		builder.append(", protocol=");
 		builder.append(protocol);
 		builder.append(", authenticatorId=");

--- a/src/main/java/org/cloudfoundry/promregator/fetcher/CFMetricsFetcher.java
+++ b/src/main/java/org/cloudfoundry/promregator/fetcher/CFMetricsFetcher.java
@@ -52,7 +52,7 @@ public class CFMetricsFetcher implements MetricsFetcher {
 	
 	private AbstractMetricFamilySamplesEnricher mfse;
 
-	static final CloseableHttpClient httpclient = HttpClients.createDefault();
+	static final CloseableHttpClient httpclient = HttpClients.createSystem();
 
 	private MetricsFetcherMetrics mfm;
 

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
@@ -450,10 +450,8 @@ public class ReactiveTargetResolver implements TargetResolver {
 							  return Mono.just(it);
 						  }).findFirst().orElseGet(Mono::empty);
 			}).doOnError(e ->
-									log.warn(String
-												 .format("Error on retrieving application annotations for org '%s', space '%s' and application '%s'.", it
-													 .getResolvedOrgName(), it.getResolvedSpaceName(), it.getConfigTarget()
-																										 .getApplicationName()), e)).flux();
+				 log.warn(String.format("Error on retrieving application annotations for org '%s', space '%s' and application '%s'.",
+										it.getResolvedOrgName(), it.getResolvedSpaceName(), it.getConfigTarget().getApplicationName()), e)).flux();
 		}
 
 		return Mono.just(it).flux();

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
@@ -22,6 +23,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import static org.cloudfoundry.promregator.cfaccessor.ReactiveCFAccessorImpl.INVALID_APPLICATIONS_RESPONSE;
+
 public class ReactiveTargetResolver implements TargetResolver {
 	private static final Logger log = LoggerFactory.getLogger(ReactiveTargetResolver.class);
 	private static final Logger logEmptyTarget = LoggerFactory.getLogger(String.format("%s.EmptyTarget", ReactiveTargetResolver.class.getName()));
@@ -37,6 +40,7 @@ public class ReactiveTargetResolver implements TargetResolver {
 		private String resolvedSpaceId;
 		private String resolvedApplicationName;
 		private String resolvedApplicationId;
+		private String resolvedMetricsPath;
 		
 		public IntermediateTarget() {
 			super();
@@ -50,6 +54,7 @@ public class ReactiveTargetResolver implements TargetResolver {
 			this.resolvedSpaceId = source.resolvedSpaceId;
 			this.resolvedApplicationName = source.resolvedApplicationName;
 			this.resolvedApplicationId = source.resolvedApplicationId;
+			this.resolvedMetricsPath = source.resolvedMetricsPath;
 		}
 
 		public IntermediateTarget(Target target) {
@@ -89,7 +94,7 @@ public class ReactiveTargetResolver implements TargetResolver {
 			rt.setSpaceName(this.resolvedSpaceName);
 			rt.setApplicationName(this.resolvedApplicationName);
 			rt.setProtocol(this.configTarget.getProtocol());
-			rt.setPath(this.configTarget.getPath());
+			rt.setPath(this.resolvedMetricsPath != null ? this.resolvedMetricsPath : this.configTarget.getPath());
 			rt.setApplicationId(this.resolvedApplicationId);
 			return rt;
 		}
@@ -202,6 +207,20 @@ public class ReactiveTargetResolver implements TargetResolver {
 		public void setResolvedApplicationId(String resolvedApplicationId) {
 			this.resolvedApplicationId = resolvedApplicationId;
 		}
+
+		/**
+		 * @return the resolved metrics path
+		 */
+		public String getResolvedMetricsPath() {
+			return resolvedMetricsPath;
+		}
+
+		/**
+		 * @param resolvedMetricsPath the resolvedMetricsPath to set
+		 */
+		public void setResolvedMetricsPath(String resolvedMetricsPath) {
+			this.resolvedMetricsPath = resolvedMetricsPath;
+		}
 		
 		
 	}
@@ -218,6 +237,8 @@ public class ReactiveTargetResolver implements TargetResolver {
 				.log(log.getName() + ".resolveSpace")
 				.flatMap (this::resolveApplication)
 				.log(log.getName() + ".resolveApplication")
+				.flatMap(this::resolveAnnotations)
+				.log(log.getName() + ".resolveAnnotations")
 				.map(IntermediateTarget::toResolvedTarget)
 				.sequential()
 				.distinct().collectList()
@@ -400,6 +421,42 @@ public class ReactiveTargetResolver implements TargetResolver {
 			
 			return itnew;
 		});
+	}
+
+	private Flux<IntermediateTarget> resolveAnnotations(IntermediateTarget it) {
+		if (Boolean.TRUE.equals(it.getConfigTarget().getKubernetesAnnotations())) {
+			Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> response = this.cfAccessor
+				.retrieveAllApplicationsInSpaceV3(it.getResolvedOrgId(), it.getResolvedSpaceId());
+
+			return response.flatMap(res -> {
+				if (res == null || INVALID_APPLICATIONS_RESPONSE == res) {
+					logEmptyTarget
+						.warn("Your foundation does not support V3 APIs, yet you have enabled Kubernetes Annotation filtering. Ignoring annotation filtering.");
+					return Mono.just(it);
+				}
+
+				return res.getResources().stream()
+						  .filter(app -> it.getResolvedApplicationName()
+										   .equals(app.getName().toLowerCase(Locale.ENGLISH)))
+						  .filter(app -> this.isApplicationInScrapableState(app.getState().toString()))
+						  .filter(app -> app.getMetadata() != null)
+						  .filter(app -> app.getMetadata().getAnnotations() != null)
+						  .filter(app -> app.getMetadata().getAnnotations()
+											.getOrDefault("prometheus.io/scrape", "false")
+											.equals("true"))
+						  .map(app -> {
+							  it.setResolvedMetricsPath(app.getMetadata().getAnnotations()
+														   .getOrDefault("prometheus.io/path", null));
+							  return Mono.just(it);
+						  }).findFirst().orElseGet(Mono::empty);
+			}).doOnError(e ->
+									log.warn(String
+												 .format("Error on retrieving application annotations for org '%s', space '%s' and application '%s'.", it
+													 .getResolvedOrgName(), it.getResolvedSpaceName(), it.getConfigTarget()
+																										 .getApplicationName()), e)).flux();
+		}
+
+		return Mono.just(it).flux();
 	}
 	
 	private boolean isApplicationInScrapableState(String state) {

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ResolvedTarget.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ResolvedTarget.java
@@ -17,6 +17,8 @@ public class ResolvedTarget {
 	private String protocol;
 
 	private String applicationId;
+
+	private Boolean kubernetesAnnotations = false;
 	
 	public ResolvedTarget() {
 		super();
@@ -29,6 +31,7 @@ public class ResolvedTarget {
 		this.applicationName = configTarget.getApplicationName();
 		this.path = configTarget.getPath();
 		this.protocol = configTarget.getProtocol();
+		this.kubernetesAnnotations = configTarget.getKubernetesAnnotations();
 	}
 	
 	public String getOrgName() {
@@ -64,6 +67,14 @@ public class ResolvedTarget {
 
 	public void setPath(String path) {
 		this.path = path;
+	}
+
+	public Boolean getKubernetesAnnotations() {
+		return kubernetesAnnotations;
+	}
+
+	public void setKubernetesAnnotations(Boolean kubernetesAnnotations) {
+		this.kubernetesAnnotations = kubernetesAnnotations != null ? kubernetesAnnotations : false;
 	}
 
 	public String getProtocol() {
@@ -107,6 +118,7 @@ public class ResolvedTarget {
 		result = prime * result + ((applicationName == null) ? 0 : applicationName.hashCode());
 		result = prime * result + ((orgName == null) ? 0 : orgName.hashCode());
 		result = prime * result + ((path == null) ? 0 : path.hashCode());
+		result = prime * result + ((kubernetesAnnotations == null) ? 0 : kubernetesAnnotations.hashCode());
 		result = prime * result + ((protocol == null) ? 0 : protocol.hashCode());
 		result = prime * result + ((spaceName == null) ? 0 : spaceName.hashCode());
 		result = prime * result + ((applicationId == null) ? 0 : applicationId.hashCode());
@@ -156,6 +168,13 @@ public class ResolvedTarget {
 		} else if (!path.equals(other.path)) {
 			return false;
 		}
+		if (kubernetesAnnotations == null) {
+			if (other.kubernetesAnnotations != null) {
+				return false;
+			}
+		} else if (!kubernetesAnnotations.equals(other.kubernetesAnnotations)) {
+			return false;
+		}
 		if (protocol == null) {
 			if (other.protocol != null) {
 				return false;
@@ -189,6 +208,8 @@ public class ResolvedTarget {
 		builder.append(applicationId);
 		builder.append(", path=");
 		builder.append(path);
+		builder.append(", kuberntesAnnotations=");
+		builder.append(kubernetesAnnotations.toString());
 		builder.append(", protocol=");
 		builder.append(protocol);
 		builder.append("]");

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -87,7 +87,7 @@ public class CFAccessorCacheCaffeineSpringApplication {
 		}
 
 		@Override
-		public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
 			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build());
 		}
 

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
@@ -130,11 +130,11 @@ class CFAccessorCacheCaffeineTest {
 
 	@Test
 	void testRetrieveAllApplicationIdsInSpaceV3() {
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 	}
 
 	@Test

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicSpringApplication.java
@@ -24,6 +24,7 @@ public class CFAccessorCacheClassicSpringApplication {
 		Mockito.when(mock.retrieveAllApplicationIdsInSpace("dummy1", "dummy2")).thenReturn(Mockito.mock(Mono.class));
 		Mockito.when(mock.retrieveSpaceSummary("dummy")).thenReturn(Mockito.mock(Mono.class));
 		Mockito.when(mock.retrieveAllDomains("dummy")).thenReturn(Mockito.mock(Mono.class));
+		Mockito.when(mock.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2")).thenReturn(Mockito.mock(Mono.class));
 		return mock;
 	}
 	

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
@@ -114,12 +114,11 @@ class CFAccessorCacheClassicTest {
 
 	@Test
 	void testRetrieveAllApplicationIdsInSpaceV3() {
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		// Cache not implemented
-		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 	}
 
 	@Test

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -219,7 +219,7 @@ public class CFAccessorMassMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -23,6 +23,10 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.BuildpackData;
+import org.cloudfoundry.client.v3.Lifecycle;
+import org.cloudfoundry.client.v3.LifecycleData;
+import org.cloudfoundry.client.v3.LifecycleType;
 import org.cloudfoundry.client.v3.applications.ApplicationState;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
@@ -396,7 +400,7 @@ public class CFAccessorMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
 		if (orgId.equals(UNITTEST_ORG_UUID) && spaceId.equals(UNITTEST_SPACE_UUID)) {
 			List<org.cloudfoundry.client.v3.applications.ApplicationResource> list = new LinkedList<>();
 
@@ -405,18 +409,24 @@ public class CFAccessorMock implements CFAccessor {
 																																		.state(ApplicationState.STARTED)
 																																		.createdAt(CREATED_AT_TIMESTAMP)
 																																		.id(UNITTEST_APP1_UUID)
+																																		.lifecycle(Lifecycle.builder().data(BuildpackData.builder().build()).type(LifecycleType.BUILDPACK).build())
+																																		.metadata(org.cloudfoundry.client.v3.Metadata.builder().annotation("prometheus.io/scrape", "true").build())
 																																		.build();
 			list.add(ar);
 
 			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
 																			.name("testapp2").state(ApplicationState.STARTED)
 																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID)
+																			.lifecycle(Lifecycle.builder().data(BuildpackData.builder().build()).type(LifecycleType.BUILDPACK).build())
+																			.metadata(org.cloudfoundry.client.v3.Metadata.builder().annotation("prometheus.io/scrape", "badValue").build())
 																			.build();
 			list.add(ar);
 
 			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
 																			.name("internalapp").state(ApplicationState.STARTED)
 																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID)
+																			.lifecycle(Lifecycle.builder().data(BuildpackData.builder().build()).type(LifecycleType.BUILDPACK).build())
+																			.metadata(org.cloudfoundry.client.v3.Metadata.builder().annotation("prometheus.io/scrape", "true").annotation("prometheus.io/path", "/actuator/prometheus").build())
 																			.build();
 			list.add(ar);
 

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
@@ -89,4 +89,40 @@ class CFAccessorSimulatorTest {
 		Assertions.assertTrue(sharedDomain.getEntity().getInternal());
 		Assertions.assertEquals(CFAccessorSimulator.INTERNAL_DOMAIN, sharedDomain.getEntity().getName());
 	}
+
+	@Test
+	void testRetrieveOrgIdV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveOrgId("simorg"));
+	}
+
+	@Test
+	void testRetrieveSpaceIdV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveSpaceIdV3(CFAccessorSimulator.ORG_UUID, "simspace"));
+	}
+
+	@Test
+	void testRetrieveAllDomainsV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveAllDomainsV3(CFAccessorSimulator.ORG_UUID));
+	}
+
+	@Test
+	void testRetrieveRoutes3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveRoutesForAppId("simapp"));
+	}
+
+	@Test
+	void testRetrieveAllSpacesV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveSpaceIdsInOrgV3(CFAccessorSimulator.ORG_UUID));
+	}
+
+	@Test
+	void testRetrieveSpaceV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveSpaceV3("simspace"));
+	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/scanner/ResolvedTargetTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/scanner/ResolvedTargetTest.java
@@ -15,6 +15,7 @@ class ResolvedTargetTest {
 		
 		subject.setPath("/path/test");
 		subject.setProtocol("https");
+		subject.setKubernetesAnnotations(true);
 		
 		String answer = subject.toString();
 		
@@ -23,6 +24,7 @@ class ResolvedTargetTest {
 		Assertions.assertTrue(answer.contains("testapp"));
 		Assertions.assertTrue(answer.contains("/path/test"));
 		Assertions.assertTrue(answer.contains("https"));
+		Assertions.assertTrue(answer.contains("kuberntesAnnotations=true"));
 	}
 
 }


### PR DESCRIPTION
* Using the V3 API for nessesary calls. Stubs remain for other V3 API calls to ease implementation in the future
* The V3 Info endpoint is not supported in the CF Java client so I added a simple custom implementation since we just check for the existance of the endpoint
* In the event that the V3 APIs are not detected but you enabled Kubernetes annotations, the property is just ignored.
* I noticed some pre-existing issues with the implementation of AutoRefreshingCacheMap. During tests it will sometimes have a background
thread remove the cache before the test can complete. This means that tests will sometimes pass and sometimes fail.

Fixes VITE-1251

